### PR TITLE
Use all Scala versions on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.14]
+        scala: [2.12.14, 2.13.6]
         java: [adopt@1.8, adopt@1.11, adopt@1.16]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,9 @@ val Scala213 = "2.13.6"
 
 val Scala212Cond = s"matrix.scala == '$Scala212'"
 
+ThisBuild / scalaVersion := Scala213
+ThisBuild / crossScalaVersions := Seq(Scala212, Scala213)
+
 def rubySetupSteps(cond: Option[String]) = Seq(
   WorkflowStep.Use(
     UseRef.Public("ruby", "setup-ruby", "v1"),
@@ -80,8 +83,6 @@ lazy val contributors = Seq(
 // General Settings
 lazy val commonSettings = Seq(
   organization := "io.chrisdavenport",
-  scalaVersion := Scala213,
-  crossScalaVersions := Seq(Scala212, scalaVersion.value),
   scalacOptions ++= Seq("-Yrangepos", "-language:higherKinds"),
   addCompilerPlugin(
     "org.typelevel" % "kind-projector" % kindProjectorV cross CrossVersion.full


### PR DESCRIPTION
It seems that `sbt-github-actions` plugin can generate Scala version matrix only if versions are defined at the top-level of `build.sbt` 🤷🏻‍♂️ 